### PR TITLE
Release: v1.7.4

### DIFF
--- a/change_request.yml
+++ b/change_request.yml
@@ -15,5 +15,5 @@ CustomFields:
   WillAffectExternalCustomers: false
   WillAffectInternalCustomers: false
   IsProductionEnvironment: false
-  ApplicationVersion: v1.7.3
+  ApplicationVersion: v1.7.4
   SystemName: Centrifugo


### PR DESCRIPTION
v1.7.4
======

No backwards incompatible changes here.

This release is centered around internal refactoring to detach node from server - see more details in [#186](https://github.com/centrifugal/centrifugo/pull/186).

**Features**

* optionally create PID file using `--pid_file` command line option.
* create connections in separate goroutines to slightly improve GC (and therefore reduce memory usage).

**Internal (for developers/contributors)**

* Using Go 1.8.3 for builds