### PR TITLE
[develop] Release/v1.7.5

### DIFF
--- a/change_request.yml
+++ b/change_request.yml
@@ -15,5 +15,5 @@ CustomFields:
   WillAffectExternalCustomers: false
   WillAffectInternalCustomers: false
   IsProductionEnvironment: false
-  ApplicationVersion: v1.7.4
+  ApplicationVersion: v1.7.5
   SystemName: Centrifugo


### PR DESCRIPTION
## Motivo da mudança

Na sexta feira dia 03/12/21 o SOC reportou um problema de segurança na aplicação do Centrífugo e desativou o DNS externo. Com a remoção do DNS as aplicações do front do Celebro pararam de receber os feedbacks de criação de caso automático no Salesforce em tempo real.

Para resolver o problema tivemos que migrar o Centrífugo para o cloud do GKE para tratar a falha de segurança identificada.
​
## Qual o tipo dessa mudança?
​
- [ ] Planejado
- [x] Emergencial
​
## Em qual ambiente será aplicada a mudança?
​
- [x] Aplicação
- [ ] Infraestrutura
​
## Qual o risco aplicado a essa mudança?
​
- [x] Baixo
- [ ] Médio
- [ ] Alto
​
## Existe um plano de rollback automatizado?
​
- [ ] Sim
- [x] Não
​
## Em caso de Rollback Manual, explique o processo.
​
Disparar a última release produtiva a partir do VSTS.
​
## Links das demandas que estão sendo resolvidas com a mudança.
​
## Teste de funcionalidade foi realizado? (Antes de colocar em produção)
​
- [x] Sim
- [ ] Não
​
## Há evidências de teste?
​
- [x] Sim
- [ ] Não
​
## Descreva como foi o teste e coloque em anexo as evidências.

Foi feito as alterações do dns e da secret em ambiente de Staging do novo centrifugo na aplicações Go-Agent e Iris. Ao abrir o Agent Dashboard foi verificado a conexão com o centrifugo e feito uma alteração de cadastro de endereço, com isso, e foi observado o comportamento em que a Iris retorna o feedback dos "steps" do processo no front do celebro em tempo real.

![2021-12-16_05-45](https://user-images.githubusercontent.com/2077886/146376898-9c5772a9-0b33-45e4-bf15-cd81df7b56a7.png)
![2021-12-16_05-39_2](https://user-images.githubusercontent.com/2077886/146376901-b6b6fbf4-9c3e-4488-8c38-6ed4f9d49ca0.png)
![2021-12-15_20-52](https://user-images.githubusercontent.com/2077886/146376903-84d7ff00-d64e-4df4-b258-826277d71317.png)


## Quem são os aprovadores?
​
- Aprovador Desenvolvimento: jean.souza@stone.com.br
- Aprovador Negócio: gtavares@stone.com.br